### PR TITLE
Remove executable sections.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ cabal-dev
 *.hi
 *.chi
 *.chs.h
+*.sw[po]
 .virthualenv
+.cabal-sandbox

--- a/wai-route.cabal
+++ b/wai-route.cabal
@@ -16,7 +16,7 @@ maintainer:          Roman S. Borschel <roman@pkaboo.org>
 copyright:           2014 Roman S. Borschel
 category:            Web
 build-type:          Simple
-extra-source-files:  README.md
+extra-source-files:  README.md, sample/*.hs
 cabal-version:       >=1.10
 
 source-repository head
@@ -43,26 +43,8 @@ library
         -fwarn-tabs
         -O2
 
-executable wai-route-sample
-    default-language: Haskell2010
-    main-is: sample/Main.hs
-
-    build-depends:
-        base
-      , bytestring     >= 0.10
-      , http-types     >= 0.8
-      , text           >= 0.11
-      , wai            >= 2.0
-      , wai-route
-      , warp           >= 2.0
-
-    ghc-options:
-        -Wall
-        -fwarn-tabs
-        -threaded
-        -with-rtsopts=-T
-
-executable wai-route-test
+test-suite wai-route-test
+    type:             exitcode-stdio-1.0
     default-language: Haskell2010
     hs-source-dirs:   test
     main-is:          Main.hs


### PR DESCRIPTION
'wai-route-test' is turned into a 'test-suite' and the sample is not
build but included as an extra source file.

This change should reduce the number of dependencies (e.g. warp, tasty)
which are only required for testing.
