### PR TITLE
Augment routing tree to include path template.

### DIFF
--- a/src/Network/Wai/Route.hs
+++ b/src/Network/Wai/Route.hs
@@ -30,9 +30,9 @@ route :: Monad m
       -> Request
       -> (Response -> m ResponseReceived)
       -> m ResponseReceived
-route rs rq k = case lookup (fromList rs) path of
-    Just (f, c) -> f c rq k
-    Nothing     -> k notFound
+route rs rq k = case lookup (fromList rs) segs of
+    Just  e -> value e (captured $ captures e) rq k
+    Nothing -> k notFound
   where
-    path     = segments (rawPathInfo rq)
+    segs     = segments (rawPathInfo rq)
     notFound = responseLBS status404 [] L.empty

--- a/test/Test/Network/Wai/Route.hs
+++ b/test/Test/Network/Wai/Route.hs
@@ -98,6 +98,3 @@ genReq r reserved = do
     segs = C.split '/' r
     toSeg (s, v) | C.head s == ':' = urlEncode False v
                  | otherwise       = urlEncode False s
-
-instance Show Request where
-    show = show . rawPathInfo

--- a/wai-route.cabal
+++ b/wai-route.cabal
@@ -1,5 +1,5 @@
 name:                wai-route
-version:             0.2
+version:             0.3
 synopsis:            Minimalistic, efficient routing for WAI
 description:
     .
@@ -32,7 +32,7 @@ library
 
     build-depends:
         base                 == 4.*
-      , wai                  == 3.0.*
+      , wai                  >= 3.0.2 && < 3.1
       , unordered-containers >= 0.2
       , http-types           >= 0.8
       , bytestring           >= 0.10


### PR DESCRIPTION
Storing the path template as part of the payload allows inspection
of this value after tree construction.

Also add a couple of helpers to allow replacing wai-routing's
intermediate list `[(ByteString, App m)]` with `Tree (App m)`, namely
the ability to fold over the tree.
